### PR TITLE
Fix loading of certain files

### DIFF
--- a/classes/WPEditorAjax.php
+++ b/classes/WPEditorAjax.php
@@ -35,7 +35,7 @@ class WPEditorAjax {
       $result[1] = '<h3>' . __('Success', 'wp-editor') . '</h3><p>' . $_REQUEST['_success'] . '</p>'; 
     }
     
-    $out = json_encode($result);
+    $out = wp_json_encode($result);
     echo $out;
     die();
   }
@@ -48,7 +48,7 @@ class WPEditorAjax {
     elseif(isset($_POST['current_plugin_root'])) {
       $upload = WPEditorBrowser::uploadPluginFiles();
     }
-    echo json_encode($upload);
+    echo wp_json_encode($upload);
     die();
   }
   
@@ -100,7 +100,7 @@ class WPEditorAjax {
       $result[2] = $_POST['extension'];
     }
     
-    $out = json_encode($result);
+    $out = wp_json_encode($result);
     echo $out;
     die();
   }  
@@ -119,7 +119,7 @@ class WPEditorAjax {
     if(isset($_REQUEST['type'])) {
       $type = $_REQUEST['type'];
     }
-    $out = json_encode(WPEditorBrowser::getFilesAndFolders($dir, $contents, $type));
+    $out = wp_json_encode(WPEditorBrowser::getFilesAndFolders($dir, $contents, $type));
     echo $out;
     die();
   }


### PR DESCRIPTION
Something about the contents of a couple of my files caused json_encode to error out. This caused WP Editor to display an error after clicking on a file to edit it. `json_last_error_msg()` returned "Malformed UTF-8 characters, possibly incorrectly encoded". `wp_json_encode` has additional code that corrects the problem and then re-attempts the `json_encode`. This resolved the issue for me.

Because `wp_json_encode` is just a wrapper around `json_encode` that provides additional error checking, this change isn't likely to have any negative effects.