### PR TITLE
chek php 7 or greater warning

### DIFF
--- a/classes/WPEditor.php
+++ b/classes/WPEditor.php
@@ -321,7 +321,7 @@ class WPEditor {
 	}
 	
 	public static function replace_plugin_edit_links( $links ) {
-		$data = '';
+		$data = array();
 		if ( isset( $_REQUEST['plugin_status'] ) && in_array( $_REQUEST['plugin_status'], array( 'mustuse', 'dropins' ) ) ) {
 			$data = $links;
 		}


### PR DESCRIPTION
PHP 7 and higher cause a warning if the variable specified as a string is subsequently assigned values as if it were an array.
MB this warning take and in php early versions i don`t known