### PR TITLE
Fix return type of plugin_action_links

### DIFF
--- a/classes/WPEditor.php
+++ b/classes/WPEditor.php
@@ -321,7 +321,7 @@ class WPEditor {
 	}
 	
 	public static function replace_plugin_edit_links( $links ) {
-		$data = '';
+		$data = array();
 		if ( isset( $_REQUEST['plugin_status'] ) && in_array( $_REQUEST['plugin_status'], array( 'mustuse', 'dropins' ) ) ) {
 			$data = $links;
 		}


### PR DESCRIPTION
As per the [plugin_action_links documentation](https://developer.wordpress.org/reference/hooks/plugin_action_links/) the hook should return an array, without this patch there is a possibility that an empty string is returned.